### PR TITLE
Fix for issue 7

### DIFF
--- a/lib/i18n/backend/active_record/missing.rb
+++ b/lib/i18n/backend/active_record/missing.rb
@@ -41,7 +41,7 @@ module I18n
           key = normalize_flat_keys(locale, key, scope, separator)
 
           unless ActiveRecord::Translation.locale(locale).lookup(key).exists?
-            interpolations = options.keys - Base::RESERVED_KEYS
+            interpolations = options.keys - I18n::RESERVED_KEYS
             keys = count ? I18n.t('i18n.plural.keys', :locale => locale).map { |k| [key, k].join(FLATTEN_SEPARATOR) } : [key]
             keys.each { |key| store_default_translation(locale, key, interpolations) }
           end


### PR DESCRIPTION
RESERVED_KEYS moved from I18n::Backend::Base to I18n in master, so we have to use I18n::RESERVED_KEYS instead of Base::RESERVED_KEYS
