### PR TITLE
deep-symbolize-keys on Hash value

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -36,7 +36,11 @@ module I18n
           if result.empty?
             nil
           elsif result.first.key == key
-            result.first.value
+            if result.first.value.respond_to?(:deep_symbolize_keys)
+              result.first.value.deep_symbolize_keys
+            else
+              result.first.value
+            end
           else
             chop_range = (key.size + FLATTEN_SEPARATOR.size)..-1
             result = result.inject({}) do |hash, r|


### PR DESCRIPTION
This dummy-proofs the Translation class so that, if a value is serialized as a Hash with string keys, it deep_symbolizes the value just like if multiple keys were returned.  I considered the overhead issue here (i.e. why not just do the values properly in the first place?); however, I think it's probably a bad idea to use the ActiveRecord backend without the Cache extension, so I consider the overhead negligible.
