### PR TITLE
Fix README – I18n::Backend::ActiveRecord already includes I18n::Backend::Flatten

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -54,7 +54,6 @@ A more adavanced example (Thanks Moritz), which uses YAML files and ActiveRecord
   I18n.backend = I18n::Backend::ActiveRecord.new
 
   I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
-  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Flatten)
   I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
   I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
 


### PR DESCRIPTION
I think you don't want to include I18n::Backend::Flatten again, because aleady includes it.

> I18n::Backend::ActiveRecord.included_modules.include?(I18n::Backend::Flatten)
=> true