### PR TITLE
A fix for error "Mysql2::Error: Table 'transl_development.translations' doesn't exist: SHOW FIELDS FROM `translations`"

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -30,20 +30,24 @@ module I18n
       protected
 
         def lookup(locale, key, scope = [], options = {})
-          key = normalize_flat_keys(locale, key, scope, options[:separator])
-          result = Translation.locale(locale).lookup(key).all
-
-          if result.empty?
+          unless Translation.table_exists?
             nil
-          elsif result.first.key == key
-            result.first.value
           else
-            chop_range = (key.size + FLATTEN_SEPARATOR.size)..-1
-            result = result.inject({}) do |hash, r|
-              hash[r.key.slice(chop_range)] = r.value
-              hash
+            key = normalize_flat_keys(locale, key, scope, options[:separator])
+            result = Translation.locale(locale).lookup(key).all
+
+            if result.empty?
+              nil
+            elsif result.first.key == key
+              result.first.value
+            else
+              chop_range = (key.size + FLATTEN_SEPARATOR.size)..-1
+              result = result.inject({}) do |hash, r|
+                hash[r.key.slice(chop_range)] = r.value
+                hash
+              end
+              result.deep_symbolize_keys
             end
-            result.deep_symbolize_keys
           end
         end
 


### PR DESCRIPTION
Using Rails version 3.1.3 (but i think, it could apply for 3.1.x)

Steps to reproduce:
1. create new rails app
2. create translation model
3. add config/initializers/locale.rb file with required configuration
4. run rake db:migrate (the exception is thrown)


I have narrowed it down to this commit in rails: https://github.com/rails/rails/commit/c19bd4f88ea5cf56b2bc8ac0b97f59c5c89dbff7#activerecord/lib/active_record/railtie.rb

During initialization of ActiveRecord it tests translation for 'activerecord.attributes' and 'activerecord.models' 
In the described scenario migrations for Translation model has not been run yet, so table is missing and exception is thrown.
