### PR TITLE
Fixes Rails 3.2 set_table_name deprecated method to table_name=

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -49,7 +49,7 @@ module I18n
         TRUTHY_CHAR = "\001"
         FALSY_CHAR = "\002"
 
-        set_table_name 'translations'
+        table_name = 'translations'
         attr_protected :is_proc, :interpolations
 
         serialize :value


### PR DESCRIPTION
Fixed: DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from class:Translation.
