### PR TITLE
Calling set_table_name is deprecated.

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -49,7 +49,7 @@ module I18n
         TRUTHY_CHAR = "\001"
         FALSY_CHAR = "\002"
 
-        set_table_name 'translations'
+        self.table_name = 'translations'
         attr_protected :is_proc, :interpolations
 
         serialize :value


### PR DESCRIPTION
Rails 3.2 warns about Calling set_table_name is deprecated.

DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from class:Translation at ... /i18n-active_record-b631b05a96d5/lib/i18n/backend/active_record/translation.rb:52)

Changed 'set_table_name' to 'self.table_name ='.
