### PR TITLE
Rails 3.2 deprecation fix: set_table_name, not actually needed here

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -49,7 +49,6 @@ module I18n
         TRUTHY_CHAR = "\001"
         FALSY_CHAR = "\002"
 
-        set_table_name 'translations'
         attr_protected :is_proc, :interpolations
 
         serialize :value


### PR DESCRIPTION
This is just a tiny quick-fix, hope you can use it.

Questions/comments welcome :)
