### PR TITLE
Update translation.rb

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -49,7 +49,7 @@ module I18n
         TRUTHY_CHAR = "\001"
         FALSY_CHAR = "\002"
 
-        set_table_name 'translations'
+        self.table_name 'translations'
         attr_protected :is_proc, :interpolations
 
         serialize :value


### PR DESCRIPTION
'set_table_name' is removed from rails 4, use 'self.table_name=' instead.
