### PR TITLE
Store missings for all available locales

### DIFF
--- a/lib/i18n/backend/active_record/missing.rb
+++ b/lib/i18n/backend/active_record/missing.rb
@@ -39,9 +39,19 @@ module I18n
           count, scope, default, separator = options.values_at(:count, :scope, :default, :separator)
           separator ||= I18n.default_separator
           key = normalize_flat_keys(locale, key, scope, separator)
+          interpolations = options.keys - I18n::RESERVED_KEYS
 
+          if I18n::available_locales.any?
+            I18n::available_locales.each do |a_locale|
+              store_if_not_exists(a_locale, key, interpolations)
+            end
+          else
+            store_if_not_exists(locale, key, interpolations)
+          end
+        end
+
+        def store_if_not_exists(locale, key, interpolations)
           unless ActiveRecord::Translation.locale(locale).lookup(key).exists?
-            interpolations = options.keys - I18n::RESERVED_KEYS
             keys = count ? I18n.t('i18n.plural.keys', :locale => locale).map { |k| [key, k].join(FLATTEN_SEPARATOR) } : [key]
             keys.each { |key| store_default_translation(locale, key, interpolations) }
           end

--- a/lib/i18n/backend/active_record/missing.rb
+++ b/lib/i18n/backend/active_record/missing.rb
@@ -43,14 +43,14 @@ module I18n
 
           if I18n::available_locales.any?
             I18n::available_locales.each do |a_locale|
-              store_if_not_exists(a_locale, key, interpolations)
+              store_if_not_exists(a_locale, key, interpolations, count)
             end
           else
-            store_if_not_exists(locale, key, interpolations)
+            store_if_not_exists(locale, key, interpolations, count)
           end
         end
 
-        def store_if_not_exists(locale, key, interpolations)
+        def store_if_not_exists(locale, key, interpolations, count)
           unless ActiveRecord::Translation.locale(locale).lookup(key).exists?
             keys = count ? I18n.t('i18n.plural.keys', :locale => locale).map { |k| [key, k].join(FLATTEN_SEPARATOR) } : [key]
             keys.each { |key| store_default_translation(locale, key, interpolations) }


### PR DESCRIPTION
When a key is missing and it is stored in DB, it should be stored for each of the available_locales instead of just the current one.

This way, when it is time to manage the stored translations from a web view, the key can be translated in all available_locales.