### PR TITLE
Improves documentation

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -51,14 +51,19 @@ A more adavanced example (Thanks Moritz), which uses YAML files and ActiveRecord
 
 <pre>
   require 'i18n/backend/active_record'
-  I18n.backend = I18n::Backend::ActiveRecord.new
+  
+  Translation  = I18n::Backend::ActiveRecord::Translation
+  
+  if Translation.table_exists?
+    I18n.backend = I18n::Backend::ActiveRecord.new
 
-  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
-  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Flatten)
-  I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
-  I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+    I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+    I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Flatten)
+    I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
+    I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
 
-  I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, I18n.backend)
+    I18n.backend = I18n::Backend::Chain.new(I18n::Backend::Simple.new, I18n.backend)
+  end
 </pre>
 
 h2. Usage


### PR DESCRIPTION
Many people fall on this trap where the migrations that create the Translation table can't run because the table doesn't exist :omg:
