### PR TITLE
Make Translation.available_locales select distinct values.

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -73,7 +73,7 @@ module I18n
           end
 
           def available_locales
-            Translation.distinct(:locale).map { |t| t.locale.to_sym }
+            Translation.distinct.pluck(:locale).map(&:to_sym)
           end
         end
 


### PR DESCRIPTION
Found on Rails 4.1.1. I haven't tested it on other Rails versions.

Before:
```ruby
> Translation.available_locales
SELECT DISTINCT `translations`.* FROM `translations`
```

After:
```ruby
> Translation.distinct.pluck(:locale).map(&:to_sym)
SELECT DISTINCT `translations`.`locale` FROM `translations`
```

This change also avoids `ActiveRecord` object allocations by plucking just the locale attribute.