### PR TITLE
Rails 4.1.5 Update & Clarify Translation.interpolations field

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -70,6 +70,12 @@ h2. Usage
 
 You can now use @I18n.t('Your String')@ to lookup translations in the database.
 
+h2. Missing Translations -> Interpolations
+
+The interpolations field in the Translations table is used by I18n::Backend::ActiveRecord::Missing to store the interpolations seen the first time this Translation was requested.  This will help translators understand what interpolations to expect, and thus to include when providing the translations.
+
+The interpolations field is otherwise unused since the "value" in Translation.value is actually used for interpolation during actual translations..
+
 h2. Maintainers
 
 * Sven Fuchs

--- a/lib/i18n/backend/active_record/missing.rb
+++ b/lib/i18n/backend/active_record/missing.rb
@@ -54,10 +54,17 @@ module I18n
         end
 
         def translate(locale, key, options = {})
-          super
-        rescue I18n::MissingTranslationData => e
-          self.store_default_translations(locale, key, options)
-          raise e
+          # super used to raise I18n::MissingTranslationData, but not any more
+          # Rails 4.1.5 and 0.7.0.beta1 result in super throwing :exception, so we need to catch :exception
+          result = catch(:exception) do
+              super
+          end
+            
+          if result.is_a? I18n::MissingTranslation
+            self.store_default_translations(locale, key, options)
+            raise result.to_exception
+          end
+          return result
         end
       end
     end


### PR DESCRIPTION
Couldn't figure out what the interpolations field was for, so I dug into it and added an explanation.

Also updated for Rails 4.1.5 since i18n no longer raises exceptions, but rather throws :exception