### PR TITLE
Use destroy over delete when deleting translation records

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    i18n-active_record (0.1.0)
+    i18n-active_record (0.1.1)
       i18n (>= 0.5.0)
 
 GEM

--- a/README.textile
+++ b/README.textile
@@ -66,6 +66,14 @@ A more advanced example (Thanks Moritz), which uses YAML files and ActiveRecord 
   end
 </pre>
 
+You may also configure whether the ActiveRecord backend should use @destroy@ or @delete@ when cleaning up internally.
+
+<pre>
+I18n::Backend::ActiveRecord.configure do |config|
+  config.cleanup_with_destroy = true # defaults to false
+end
+</pre>
+
 h2. Usage
 
 You can now use @I18n.t('Your String')@ to lookup translations in the database.

--- a/lib/i18n/active_record/version.rb
+++ b/lib/i18n/active_record/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module ActiveRecord
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/lib/i18n/backend/active_record/configuration.rb
+++ b/lib/i18n/backend/active_record/configuration.rb
@@ -1,0 +1,13 @@
+module I18n
+  module Backend
+    class ActiveRecord
+      class Configuration
+        attr_accessor :cleanup_with_destroy
+
+        def initialize
+          @cleanup_with_destroy = false
+        end
+      end
+    end
+  end
+end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -8,6 +8,7 @@ class I18nBackendActiveRecordTest < I18n::TestCase
 
   def teardown
     I18n::Backend::ActiveRecord::Translation.destroy_all
+    I18n::Backend::ActiveRecord.instance_variable_set :@config, I18n::Backend::ActiveRecord::Configuration.new
     super
   end
 
@@ -62,5 +63,17 @@ class I18nBackendActiveRecordTest < I18n::TestCase
     assert_includes available_locales, :en
     assert_includes available_locales, :de
     assert_includes available_locales, :uk
+  end
+
+  test "the default configuration has cleanup_with_destroy == false" do
+    refute I18n::Backend::ActiveRecord.config.cleanup_with_destroy
+  end
+
+  test "the configuration supports cleanup_with_destroy being set" do
+    I18n::Backend::ActiveRecord.configure do |config|
+      config.cleanup_with_destroy = true
+    end
+
+    assert I18n::Backend::ActiveRecord.config.cleanup_with_destroy
   end
 end


### PR DESCRIPTION
Ensures that rails callbacks get called on destroy.