### PR TITLE
Fix inconsistency with other I18n backends

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -52,8 +52,14 @@ module I18n
           result = Translation.locale(locale).lookup(key)
 
           if result.empty?
-            nil
-          elsif result.first.key == key
+            if key == '.'
+              result = Translation.locale(locale).all
+            else
+              return nil
+            end
+          end
+
+          if result.first.key == key
             result.first.value
           else
             result = result.inject({}) do |hash, translation|
@@ -65,7 +71,11 @@ module I18n
 
         def build_translation_hash_by_key(lookup_key, translation)
           hash = {}
-          chop_range = (lookup_key.size + FLATTEN_SEPARATOR.size)..-1
+          if lookup_key == '.'
+            chop_range = 0..-1
+          else
+            chop_range = (lookup_key.size + FLATTEN_SEPARATOR.size)..-1
+          end
           translation_nested_keys = translation.key.slice(chop_range).split(FLATTEN_SEPARATOR)
           translation_nested_keys.each.with_index.inject(hash) do |iterator, (key, index)|
             iterator[key] = translation_nested_keys[index + 1] ?  {} : translation.value

--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -51,15 +51,13 @@ module I18n
           key = normalize_flat_keys(locale, key, scope, options[:separator])
           result = Translation.locale(locale).lookup(key)
 
-          if result.empty?
-            if key == '.'
-              result = Translation.locale(locale).all
-            else
-              return nil
-            end
+          if result.empty? && key == '.'
+            result = Translation.locale(locale).all
           end
 
-          if result.first.key == key
+          if result.empty?
+            nil
+          elsif result.first.key == key
             result.first.value
           else
             result = result.inject({}) do |hash, translation|

--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -49,10 +49,10 @@ module I18n
 
         def lookup(locale, key, scope = [], options = {})
           key = normalize_flat_keys(locale, key, scope, options[:separator])
-          result = Translation.locale(locale).lookup(key)
-
-          if result.empty? && key == '.'
-            result = Translation.locale(locale).all
+          result = if key == '.'
+            Translation.locale(locale).all
+          else
+            Translation.locale(locale).lookup(key)
           end
 
           if result.empty?

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -93,4 +93,11 @@ class I18nBackendActiveRecordTest < I18n::TestCase
     expected_hash = {:foo => { :bar => 'bar', :baz => 'baz' }}
     assert_equal expected_hash, I18n.t('.')
   end
+
+  test "returning all keys via . when there are no keys" do
+    I18n.t('.') # Fixes test flakiness by loading available locales
+    I18n::Backend::ActiveRecord::Translation.destroy_all
+
+    assert_equal "translation missing: en.no key", I18n.t('.')
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -88,4 +88,9 @@ class I18nBackendActiveRecordTest < I18n::TestCase
     expected_hash = { 'bar' => { 'fizz' => { 'buzz' => 'translation' } } }
     assert_equal I18n.backend.send(:build_translation_hash_by_key, 'foo', translation), expected_hash
   end
+
+  test "returning all keys via ." do
+    expected_hash = {:foo => { :bar => 'bar', :baz => 'baz' }}
+    assert_equal expected_hash, I18n.t('.')
+  end
 end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative './test_helper'
 
 class I18nBackendActiveRecordTest < I18n::TestCase
   def setup


### PR DESCRIPTION
`I18n::Backend::Simple` supports returning all keys by invoking `I18n.t('.')`. This adds support for this functionality so that it is consistent with the simple backend.

I ran into this problem when using different backends across environments in rails.

Hopefully the changes I have made make sense!