### PR TITLE
Handle accessing keys with a leading period

### DIFF
--- a/gemfiles/Gemfile.rails_3.lock
+++ b/gemfiles/Gemfile.rails_3.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    i18n-active_record (0.2.0)
+    i18n-active_record (0.2.1)
       i18n (>= 0.5.0)
 
 GEM

--- a/gemfiles/Gemfile.rails_4.lock
+++ b/gemfiles/Gemfile.rails_4.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    i18n-active_record (0.2.0)
+    i18n-active_record (0.2.1)
       i18n (>= 0.5.0)
 
 GEM

--- a/gemfiles/Gemfile.rails_5.lock
+++ b/gemfiles/Gemfile.rails_5.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    i18n-active_record (0.2.0)
+    i18n-active_record (0.2.1)
       i18n (>= 0.5.0)
 
 GEM

--- a/gemfiles/Gemfile.rails_master.lock
+++ b/gemfiles/Gemfile.rails_master.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: ..
   specs:
-    i18n-active_record (0.2.0)
+    i18n-active_record (0.2.1)
       i18n (>= 0.5.0)
 
 GEM

--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -49,7 +49,11 @@ module I18n
 
         def lookup(locale, key, scope = [], options = {})
           key = normalize_flat_keys(locale, key, scope, options[:separator])
-          result = if key == '.'
+          if key.first == '.'
+            key = key[1..-1]
+          end
+
+          result = if key == ''
             Translation.locale(locale).all
           else
             Translation.locale(locale).lookup(key)
@@ -69,7 +73,7 @@ module I18n
 
         def build_translation_hash_by_key(lookup_key, translation)
           hash = {}
-          if lookup_key == '.'
+          if lookup_key == ''
             chop_range = 0..-1
           else
             chop_range = (lookup_key.size + FLATTEN_SEPARATOR.size)..-1

--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -52,6 +52,9 @@ module I18n
           if key.first == '.'
             key = key[1..-1]
           end
+          if key.last == '.'
+            key = key[0..-2]
+          end
 
           result = if key == ''
             Translation.locale(locale).all

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -94,6 +94,12 @@ class I18nBackendActiveRecordTest < I18n::TestCase
     assert_equal expected_hash, I18n.t('.')
   end
 
+  test "accessing keys with a leading period" do
+    expected_hash = { :bar => 'bar', :baz => 'baz' }
+    assert_equal expected_hash, I18n.t('foo')
+    assert_equal expected_hash, I18n.t('.foo')
+  end
+
   test "returning all keys via . when there are no keys" do
     I18n.t('.') # Fixes test flakiness by loading available locales
     I18n::Backend::ActiveRecord::Translation.destroy_all

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -94,10 +94,13 @@ class I18nBackendActiveRecordTest < I18n::TestCase
     assert_equal expected_hash, I18n.t('.')
   end
 
-  test "accessing keys with a leading period" do
+  test "accessing keys with a trailing/leading period" do
     expected_hash = { :bar => 'bar', :baz => 'baz' }
     assert_equal expected_hash, I18n.t('foo')
     assert_equal expected_hash, I18n.t('.foo')
+    assert_equal expected_hash, I18n.t('foo.')
+    assert_equal expected_hash, I18n.t('.foo.')
+    assert_equal expected_hash, I18n.t('.foo.')
   end
 
   test "returning all keys via . when there are no keys" do


### PR DESCRIPTION
Why: So that the ActiveRecord backend behaves the same as the Simple backend.