### PR TITLE
Rename recommended initializer for Rails 5 compatibility

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -39,7 +39,7 @@ Your migration should look like this:
 With this translation model you will be able to manage your translation, and add new translations or languages through
 it.
 
-To load @I18n::Backend::ActiveRecord@ into your Rails application, create a new file in *config/initializers* named *locale.rb*.
+To load @I18n::Backend::ActiveRecord@ into your Rails application, create a new file in *config/initializers* named *translation.rb*.
 
 A simple configuration for your locale.rb could look like this:
 


### PR DESCRIPTION
Fixes #78 where a reported name ordering issue happens so that
this initializer needs to be run after `new_framework_defaults.rb`