### PR TITLE
Add #translations, #init_translations and #intialized?

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -45,6 +45,24 @@ module I18n
           end
         end
 
+        def reload!
+          @translations = nil
+          self
+        end
+
+        def initialized?
+          !@translations.nil?
+        end
+
+        def init_translations
+          @translations = Translation.to_hash
+        end
+
+        def translations(do_init: false)
+          init_translations if do_init || !initialized?
+          @translations ||= {}
+        end
+
       protected
 
         def lookup(locale, key, scope = [], options = {})

--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -75,6 +75,18 @@ module I18n
           def available_locales
             Translation.select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
           end
+
+          def to_hash
+            Translation.all.each.with_object({}) do |t, memo|
+              locale_hash = (memo[t.locale.to_sym] ||= {})
+              keys = t.key.split('.')
+              keys.each.with_index.inject(locale_hash) do |iterator, (key_part, index)|
+                key = key_part.to_sym
+                iterator[key] = keys[index + 1] ? (iterator[key] || {}) : t.value
+                iterator[key]
+              end
+            end
+          end
         end
 
         def interpolates?(key)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -109,4 +109,28 @@ class I18nBackendActiveRecordTest < I18n::TestCase
 
     assert_equal "translation missing: en.no key", I18n.t('.')
   end
+
+  test "intially unitinitialized" do
+    refute I18n.backend.initialized?
+    I18n.backend.init_translations
+    assert I18n.backend.initialized?
+    I18n.backend.reload!
+    refute I18n.backend.initialized?
+    I18n.backend.init_translations
+    assert I18n.backend.initialized?
+  end
+
+  test "translations returns all translations" do
+    expected_hash = { :en => { :foo => { :bar => 'bar', :baz => 'baz' } } }
+    I18n.backend.init_translations
+    assert_equal expected_hash, I18n.backend.send(:translations)
+    assert I18n.backend.initialized?
+  end
+
+  test "translations initialized with do_init argument" do
+    expected_hash = { :en => { :foo => { :bar => 'bar', :baz => 'baz' } } }
+    refute I18n.backend.initialized?
+    assert_equal expected_hash, I18n.backend.send(:translations, { do_init: true })
+    assert I18n.backend.initialized?
+  end
 end


### PR DESCRIPTION
I'm using fnando/i18n-js in my project, which basically calls `#translations` to fetch an entire hash of translations to output in JavaScript. Their project documents that it is incompatible with anything other than a Simple backend, but it actually only requires a couple of hook methods to get working which I have added in this patch. I think that a number of users would benefit from being able to get translations from the ActiveRecord backend into the frontend.

The methods are unused inside the project itself, but I've added some tests to cover their expected behaviour.

Thanks for taking the time to take a look at this :)