### PR TITLE
Pluralize the class name

### DIFF
--- a/lib/generators/i18n/active_record/install_generator.rb
+++ b/lib/generators/i18n/active_record/install_generator.rb
@@ -19,7 +19,7 @@ module I18n
         end
 
         def create_migrations
-          migration_template 'migration.rb.erb', 'db/migrate/create_translations.rb'
+          migration_template 'migration.rb.erb', 'db/migrate/create_#{table_name}.rb'
         end
       end
     end

--- a/lib/generators/i18n/active_record/install_generator.rb
+++ b/lib/generators/i18n/active_record/install_generator.rb
@@ -19,7 +19,7 @@ module I18n
         end
 
         def create_migrations
-          migration_template 'migration.rb.erb', 'db/migrate/create_#{table_name}.rb'
+          migration_template 'migration.rb.erb', "db/migrate/create_#{table_name}.rb"
         end
       end
     end

--- a/lib/generators/i18n/active_record/templates/migration.rb.erb
+++ b/lib/generators/i18n/active_record/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class Create<%= name.classify %>s < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version.to_s %>]
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def self.up
     create_table :<%= name.tableize %> do |t|
       t.string :locale

--- a/lib/generators/i18n/active_record/templates/migration.rb.erb
+++ b/lib/generators/i18n/active_record/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class Create<%= name.classify %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version.to_s %>]
+class Create<%= name.classify %>s < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version.to_s %>]
   def self.up
     create_table :<%= name.tableize %> do |t|
       t.string :locale


### PR DESCRIPTION
Else `create_translations` file name does not map to the class `CreateTranslation` since it is missing the S.

Fixes #100 