### PR TITLE
support version 1.9.0 of i18n 

### DIFF
--- a/i18n-active_record.gemspec
+++ b/i18n-active_record.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
 
-  s.add_dependency 'i18n', '>= 0.5.0'
+  s.add_dependency 'i18n', '>= 1.9.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'bundler'

--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -97,9 +97,9 @@ module I18n
             result.first.value
           else
             result = result.inject({}) do |hash, translation|
-              hash.deep_merge build_translation_hash_by_key(key, translation)
+              Utils.deep_merge(hash, build_translation_hash_by_key(key, translation))
             end
-            result.deep_symbolize_keys
+            Utils.deep_symbolize_keys(result)
           end
         end
 


### PR DESCRIPTION
support version 1.9.0 of i18n due to https://github.com/ruby-i18n/i18n/pull/573
to fix #130.

I don't now if we can support older versions some how

Actually it works (all tests pass) on rails 5, 6 & 7 and fails in 4 for i18n>=1.9.0