### PR TITLE
Rename I18n::Backend::ActiveRecord::Translation#to_hash to #to_h 

### DIFF
--- a/lib/i18n/backend/active_record.rb
+++ b/lib/i18n/backend/active_record.rb
@@ -64,7 +64,7 @@ module I18n
         end
 
         def init_translations
-          @translations = Translation.to_hash
+          @translations = Translation.to_h
         end
 
         def translations(do_init: false)

--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -79,7 +79,7 @@ module I18n
             Translation.select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
           end
 
-          def to_hash
+          def to_h
             Translation.all.each.with_object({}) do |t, memo|
               locale_hash = (memo[t.locale.to_sym] ||= {})
               keys = t.key.split('.')


### PR DESCRIPTION
The implicit hash conversion (from `#to_hash`) causes an unexpected problem in Ruby 2.7.

```
I18n::Backend::ActiveRecord::Translation.create(locale: 'en', key: 'foo', value: 'bar')

proc = ->(scope = nil, all_queries: nil) { }
proc.call(I18n::Backend::ActiveRecord::Translation)

Traceback (most recent call last):                    
(irb):3:in `block in <main>': unknown keyword: :en (ArgumentError)
```

Renaming `#to_hash` seems sufficient to avoid this behavior.