### PR TITLE
Scope config option to isolate translations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,35 +36,41 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 'head']
-        rails: [4, 5, 6, 7, 'head']
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 'head']
+        rails: [4, 5, 6, 7, 8, 'head']
         exclude:
-          - ruby: 2.5
-            rails: 7
-          - ruby: 2.5
-            rails: head
-          - ruby: 2.6
-            rails: 7
-          - ruby: 2.6
-            rails: head
-          - ruby: 2.7
-            rails: 4
-          - ruby: '3.0'
-            rails: 4
-          - ruby: '3.0'
-            rails: 5
-          - ruby: 3.1
-            rails: 4
-          - ruby: 3.1
-            rails: 5
-          - ruby: 3.2
-            rails: 4
-          - ruby: 3.2
-            rails: 5
-          - ruby: head
-            rails: 4
-          - ruby: head
-            rails: 5
+          - { 'ruby': '2.5', 'rails': '7' }
+          - { 'ruby': '2.5', 'rails': '8' }
+          - { 'ruby': '2.5', 'rails': 'head' }
+
+          - { 'ruby': '2.6', 'rails': '7' }
+          - { 'ruby': '2.6', 'rails': '8' }
+          - { 'ruby': '2.6', 'rails': 'head' }
+
+          - { 'ruby': '2.7', 'rails': '4' }
+          - { 'ruby': '2.7', 'rails': '8' }
+          - { 'ruby': '2.7', 'rails': 'head' }
+
+          - { 'ruby': '3.0', 'rails': '4' }
+          - { 'ruby': '3.0', 'rails': '5' }
+          - { 'ruby': '3.0', 'rails': '8' }
+          - { 'ruby': '3.0', 'rails': 'head' }
+
+          - { 'ruby': '3.1', 'rails': '4' }
+          - { 'ruby': '3.1', 'rails': '5' }
+          - { 'ruby': '3.1', 'rails': '8' }
+          - { 'ruby': '3.1', 'rails': 'head' }
+
+          - { 'ruby': '3.2', 'rails': '4' }
+          - { 'ruby': '3.2', 'rails': '5' }
+
+          - { 'ruby': '3.3', 'rails': '4' }
+          - { 'ruby': '3.3', 'rails': '5' }
+
+          - { 'ruby': 'head', 'rails': '4' }
+          - { 'ruby': 'head', 'rails': '5' }
+          - { 'ruby': 'head', 'rails': '6' }
+          - { 'ruby': 'head', 'rails': '7' }
     name: 'Ruby: ${{ matrix.ruby }}, Rails: ${{ matrix.rails }}'
     runs-on: ubuntu-latest
     env:

--- a/Appraisals
+++ b/Appraisals
@@ -3,21 +3,28 @@
 appraise 'rails-4' do
   gem 'activerecord', '~> 4.2.0'
   gem 'mysql2', '~> 0.4.10'
-  gem 'sqlite3', '~> 1.3.13'
   gem 'pg', '~> 0.18.0'
+  gem 'sqlite3', '~> 1.3.13'
 end
 
 appraise 'rails-5' do
   gem 'activerecord', '~> 5.2.0'
+  gem 'sqlite3', '~> 1.3.13'
   gem 'psych', '~> 3.1'
 end
 
 appraise 'rails-6' do
   gem 'activerecord', '~> 6.1.0'
+  gem 'sqlite3',  '~> 1.4.4'
 end
 
 appraise 'rails-7' do
   gem 'activerecord', '~> 7.0.0'
+  gem 'sqlite3',  '~> 1.4.4'
+end
+
+appraise 'rails-8' do
+  gem 'activerecord', '~> 8.0.0'
 end
 
 appraise 'rails-head' do

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ I18n::Backend::ActiveRecord.configure do |config|
 end
 ```
 
+The ActiveRecord backend can be configured to use a `scope` to isolate sets of translations. That way, two applications
+using the backend with the same database table can use translation data independently of one another.
+If configured with a scope, all data used will be limited to records with that particular scope identifier:
+
+```ruby
+I18n::Backend::ActiveRecord.configure do |config|
+  config.scope = 'app1' # defaults to nil, disabling scope
+end
+```
+
 ## Usage
 
 You can now use `I18n.t('Your String')` to lookup translations in the database.

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 6.1.0"
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gem "activerecord", "~> 7.0.0"
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.gemfile
+++ b/gemfiles/rails_8.gemfile
@@ -2,10 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.2.0"
+gem "activerecord", "~> 8.0.0"
 gem "mysql2"
 gem "pg"
-gem "sqlite3", "~> 1.3.13"
-gem "psych", "~> 3.1"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/lib/generators/i18n/active_record/templates/advanced_initializer.rb.erb
+++ b/lib/generators/i18n/active_record/templates/advanced_initializer.rb.erb
@@ -15,4 +15,5 @@ end
 I18n::Backend::ActiveRecord.configure do |config|
   # config.cache_translations = true # defaults to false
   # config.cleanup_with_destroy = true # defaults to false
+  # config.scope = 'app_scope' # defaults to nil, won't be used
 end

--- a/lib/generators/i18n/active_record/templates/migration.rb.erb
+++ b/lib/generators/i18n/active_record/templates/migration.rb.erb
@@ -1,6 +1,7 @@
 class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :<%= table_name %> do |t|
+      t.string :scope
       t.string :locale
       t.string :key
       t.text :value

--- a/lib/generators/i18n/active_record/templates/simple_initializer.rb.erb
+++ b/lib/generators/i18n/active_record/templates/simple_initializer.rb.erb
@@ -4,4 +4,5 @@ I18n.backend = I18n::Backend::ActiveRecord.new
 I18n::Backend::ActiveRecord.configure do |config|
   # config.cache_translations = true # defaults to false
   # config.cleanup_with_destroy = true # defaults to false
+  # config.scope = 'app_scope' # defaults to nil, won't be used
 end

--- a/lib/i18n/backend/active_record/configuration.rb
+++ b/lib/i18n/backend/active_record/configuration.rb
@@ -4,12 +4,13 @@ module I18n
   module Backend
     class ActiveRecord
       class Configuration
-        attr_accessor :cleanup_with_destroy, :cache_translations, :translation_model
+        attr_accessor :cleanup_with_destroy, :cache_translations, :translation_model, :scope
 
         def initialize
           @cleanup_with_destroy = false
           @cache_translations = false
           @translation_model = I18n::Backend::ActiveRecord::Translation
+          @scope = nil
         end
       end
     end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -191,4 +191,35 @@ class I18nBackendActiveRecordTest < I18n::TestCase
       assert_equal I18n.t(:foo), 'custom foo'
     end
   end
+
+  class ScopeTest < I18nBackendActiveRecordTest
+    def setup
+      super
+
+      I18n::Backend::ActiveRecord.config.scope = 'scope1'
+    end
+
+    test 'scope config option divides translations into isolated sets' do
+      store_translations(:en, foo: 'foo1')
+      assert_equal('foo1', I18n.t(:foo))
+
+      I18n::Backend::ActiveRecord.config.scope = 'scope2'
+      store_translations(:en, foo: 'foo2')
+      assert_equal('foo2', I18n.t(:foo))
+
+      I18n::Backend::ActiveRecord.config.scope = 'scope1'
+      assert_equal('foo1', I18n.t(:foo))
+    end
+
+    test 'scope config of nil disables scope' do
+      store_translations(:en, bar1: 'bar1')
+
+      I18n::Backend::ActiveRecord.config.scope = 'scope2'
+      store_translations(:en, bar2: 'bar2')
+
+      I18n::Backend::ActiveRecord.config.scope = nil
+      assert_equal('bar1', I18n.t(:bar1))
+      assert_equal('bar2', I18n.t(:bar2))
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,13 +40,14 @@ rescue ActiveRecord::ConnectionNotEstablished
   ActiveRecord::Migration.verbose = false
   ActiveRecord::Schema.define(version: 1) do
     create_table :translations, force: true do |t|
+      t.string :scope
       t.string :locale
       t.string :key
       t.text :value
       t.text :interpolations
       t.boolean :is_proc, default: false
     end
-    add_index :translations, %i[locale key], unique: true
+    add_index :translations, %i[scope locale key], unique: true
   end
 
   if ActiveRecord::Base.respond_to?(:yaml_column_permitted_classes=)


### PR DESCRIPTION
In my usage of this gem, I ran into a situation where I'd like two very related applications that are organizationally distinct but part of the same domain (e.g. public web application and its admin/management application) to connect to the same database.

However, I'd like them *not* to share translation data, and found that difficult to do without overriding methods in `I18n::Backend::ActiveRecord`. So instead, I added this feature to my fork, and wanted to see what you think about it and whether you'd be interested in having it in the main codebase.

Essentially I added a `scope` field to the migration and if the configuration option is set, then all reads/writes will be limited to only those records with that particular scope identifier. I wanted to maintain compatibility with existing tables that don't have a scope, or even newly created tables where someone wants to remove the scope field from the migration if they won't be using it.

I've added two tests showing how I think the behaviour should work and a readme paragraph. Thanks taking the time to look this over :relaxed: