### PR TITLE
Make translation model configurable

### DIFF
--- a/lib/i18n/backend/active_record/configuration.rb
+++ b/lib/i18n/backend/active_record/configuration.rb
@@ -4,11 +4,12 @@ module I18n
   module Backend
     class ActiveRecord
       class Configuration
-        attr_accessor :cleanup_with_destroy, :cache_translations
+        attr_accessor :cleanup_with_destroy, :cache_translations, :translation_model
 
         def initialize
           @cleanup_with_destroy = false
           @cache_translations = false
+          @translation_model = I18n::Backend::ActiveRecord::Translation
         end
       end
     end

--- a/lib/i18n/backend/active_record/missing.rb
+++ b/lib/i18n/backend/active_record/missing.rb
@@ -36,13 +36,14 @@ module I18n
     class ActiveRecord
       module Missing
         include Flatten
+        include TranslationModel
 
         def store_default_translations(locale, key, options = {})
           count, scope, _, separator = options.values_at(:count, :scope, :default, :separator)
           separator ||= I18n.default_separator
           key = normalize_flat_keys(locale, key, scope, separator)
 
-          return if ActiveRecord::Translation.locale(locale).lookup(key).exists?
+          return if translation_model.locale(locale).lookup(key).exists?
 
           interpolations = options.keys - I18n::RESERVED_KEYS
           keys = count ? I18n.t('i18n.plural.keys', locale: locale).map { |k| [key, k].join(FLATTEN_SEPARATOR) } : [key]
@@ -50,7 +51,7 @@ module I18n
         end
 
         def store_default_translation(locale, key, interpolations)
-          translation = ActiveRecord::Translation.new locale: locale.to_s, key: key
+          translation = translation_model.new locale: locale.to_s, key: key
           translation.interpolations = interpolations
           translation.save
         end

--- a/lib/i18n/backend/active_record/store_procs.rb
+++ b/lib/i18n/backend/active_record/store_procs.rb
@@ -33,7 +33,9 @@ module I18n
           end
         end
 
-        Translation.send(:include, self) if method(:to_s).respond_to?(:to_ruby)
+        if method(:to_s).respond_to?(:to_ruby)
+          I18n::Backend::ActiveRecord.config.translation_model.send(:include, self)
+        end
       end
     end
   end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -172,4 +172,23 @@ class I18nBackendActiveRecordTest < I18n::TestCase
       I18n.t('foo')
     end
   end
+
+  class WithCustomTranslationModel < I18nBackendActiveRecordTest
+    class CustomTranslation < I18n::Backend::ActiveRecord::Translation
+      def value=(v)
+        super("custom #{v}")
+      end
+    end
+
+    def setup
+      super
+
+      I18n::Backend::ActiveRecord.config.translation_model = CustomTranslation
+    end
+
+    test 'use a custom model' do
+      store_translations(:en, foo: 'foo')
+      assert_equal I18n.t(:foo), 'custom foo'
+    end
+  end
 end


### PR DESCRIPTION
See https://github.com/svenfuchs/i18n-active_record/issues/143

TLDR: In development, doing the following results in reloading issues on code changes:
```
# app/models/translation.rb
Translation = I18n::Backend::ActiveRecord::Translation
class Translation
  VALUES = ["foo", "bar"]
  validates :key, inclusion: { in: VALUES }
end
```

Reason: The constant `I18n::Backend::ActiveRecord::Translation` isn't reloaded by Zeitwerk and any changes to the constant made inside `translation.rb` get re-added on every reload.