### PR TITLE
Change using of class object for custom translation model

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -93,11 +93,11 @@ module I18n
           end
 
           def available_locales
-            self.select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
+            select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
           end
 
           def to_h
-            self.all.each.with_object({}) do |t, memo|
+            all.each.with_object({}) do |t, memo|
               locale_hash = (memo[t.locale.to_sym] ||= {})
               keys = t.key.split('.')
               keys.each.with_index.inject(locale_hash) do |iterator, (key_part, index)|

--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -93,11 +93,11 @@ module I18n
           end
 
           def available_locales
-            Translation.select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
+            self.select('DISTINCT locale').to_a.map { |t| t.locale.to_sym }
           end
 
           def to_h
-            Translation.all.each.with_object({}) do |t, memo|
+            self.all.each.with_object({}) do |t, memo|
               locale_hash = (memo[t.locale.to_sym] ||= {})
               keys = t.key.split('.')
               keys.each.with_index.inject(locale_hash) do |iterator, (key_part, index)|


### PR DESCRIPTION
When using custom translation model in config, `Translation` was still used for `to_h` method. 

This was a problem if we are using custom translation model with different serialization coder for example. This was one of solutions for changes so that current database is compatible with Rails 7.1 (https://github.com/svenfuchs/i18n-active_record/issues/147#issuecomment-1919223281).

Changing the default coder in custom translation model works, but there is a problem only if using `cache_translations` in config which this change fixes.